### PR TITLE
Minor package management changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+iniconfig==2.0.0
+packaging==24.1
+pluggy==1.5.0
+pytest==8.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ iniconfig==2.0.0
 packaging==24.1
 pluggy==1.5.0
 pytest==8.3.2
+regex==2024.7.24


### PR DESCRIPTION
Add requirements.txt
Update gitignore to ignore pyenv

Manual packet management with requirements.txt
When adding a new packet remember to
```
pip freeze > requirements.txt
```
when creating your env remember to
```
pip install -r requirements.txt
```

I prefer to use `poetry`, which is a separate tool for dependencies management but for simple projects like that requirements.txt should be enough

Updating .gitignore to allow .python-version because I use the `pyenv` tool manage my venv and ignore .idea which is where pycharm stores the config.